### PR TITLE
Use unittest instead unittest2 in tests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use unittest instead unittest2 in tests.
+  [elioschmutz]
 
 
 1.0.1 (2017-07-27)

--- a/ftw/slacker/tests/__init__.py
+++ b/ftw/slacker/tests/__init__.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from ftw.slacker.testing import FTW_SLACKER_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 from ftw.slacker import slack_notifier
 import transaction
 import os

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 version = '1.0.2.dev0'
 
 tests_require = [
-    'unittest2',
     'plone.app.testing'
 ]
 


### PR DESCRIPTION
Because we don't need backwards compatibility, we can use `unittest` instead `unittest2` for tests.